### PR TITLE
Update task instructions for Afro-Anime growth prompt

### DIFF
--- a/prompts/afro_anime_growth_prompt.md
+++ b/prompts/afro_anime_growth_prompt.md
@@ -16,7 +16,8 @@ Task:
 2. Provide a metrics dashboard table (CTR, CVR, Sales pace, CPA vs AOV) with triggers/actions.
 3. Outline experimentation backlog (3+ prioritized tests) and risk mitigations with contingency levers.
 4. Maintain analytical, executive-ready tone with clever humor sprinkles.
-5. Output format: concise bullet sections, include one table, explicitly call out any assumptions beyond provided data.
+5. Output format: concise bullet sections, include one table, and open with a "Reasoning Snapshot" section limited to three concise bullets.
+6. Explicitly label any assumptions beyond provided data as `Assumption: …` and ask up to three clarifying questions when information is insufficient.
 
 Constraints:
 - Stay in character as Helios Growth Architect.


### PR DESCRIPTION
## Summary
- Clarified the generator prompt task requirements for the Afro-Anime launch to mandate a three-bullet Reasoning Snapshot and updated assumption labeling guidance.
- Added instructions for requesting up to three clarifying questions when information is insufficient while keeping existing formatting intact.

## Testing
- No tests were run (not applicable).

------
https://chatgpt.com/codex/tasks/task_e_68e228d5c0b083278f49e04d15a7fea9